### PR TITLE
feat: flag for rustls

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,6 +23,11 @@ path = "src/lib.rs"
 base64 = "0.13"
 http-auth-basic = "0.3"
 hyper = { version = "0.14", features = ["http2"] }
-hyper-tls = "0.5"
+hyper-tls = { version = "0.5", optional = true }
+hyper-rustls = { version="0.23", features = ["http2", "webpki-roots"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[features]
+default = ["hyper-tls"]
+rustls = ["hyper-rustls"]

--- a/lib/src/api/v3/attachment.rs
+++ b/lib/src/api/v3/attachment.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 /// "Inline_attachments":[{"Content-type":"image/png","Filename":"logo.png","content":"iVBOR..."}]
 /// ```
 ///
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Attachment {
     #[serde(rename = "Content-type")]
     pub content_type: String,

--- a/lib/src/client/mailjet.rs
+++ b/lib/src/client/mailjet.rs
@@ -7,6 +7,9 @@ use http_auth_basic::Credentials;
 use hyper::client::{Client as HyperClient, HttpConnector};
 use hyper::Error as HyperError;
 use hyper::{Body, Request, Response};
+#[cfg(feature = "rustls")]
+use hyper_rustls::HttpsConnector;
+#[cfg(not(feature = "rustls"))]
 use hyper_tls::HttpsConnector;
 
 /// Mailjet's Email API uses the API keys provided by Mailjet for your account [here](https://app.mailjet.com/account/api_keys).
@@ -46,6 +49,13 @@ impl Client {
 
         let keys = Credentials::new(public_key, private_key);
         let encoded_credentials = keys.as_http_header();
+        #[cfg(feature = "rustls")]
+        let https = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http2()
+            .build();
+        #[cfg(not(feature = "rustls"))]
         let https = HttpsConnector::new();
         let http_client = HyperClient::builder().build::<_, hyper::Body>(https);
 


### PR DESCRIPTION
Allow the user to choose rustls as an alternative to native-tls. Default behavior is unchanged. Adding the following line to the Cargo.toml file would build mailjet-rs with rustls. 

```toml
mailjet-rs = { version = "0.2.2", default-features = false, features = ["rustls"] }
```